### PR TITLE
Rename time.h to not interfere with global includes

### DIFF
--- a/shaders/examples/cartoon.frag
+++ b/shaders/examples/cartoon.frag
@@ -5,7 +5,7 @@
 #include "camera.h"
 #include "geometry/box.h"
 #include "geometry/beam.h"
-#include "time.h"
+#include "simtime.h"
 
 uniform vec2 iResolution = vec2(640.,480.);
 uniform float iGlobalTime = 0.;

--- a/shaders/simtime.h
+++ b/shaders/simtime.h
@@ -1,5 +1,5 @@
-#ifndef INCLUDED_TIME_H
-#define INCLUDED_TIME_H
+#ifndef INCLUDED_SIMTIME_H
+#define INCLUDED_SIMTIME_H
 
 layout (std140) uniform time {
   float now;   // number of seconds since the start of the simulation


### PR DESCRIPTION
Build fails on linux otherwise. (As `shaders/time.h` gets included instead of `/usr/include/time.h` somewhere deep, while compiling `SDL.hsc`.)