### PR TITLE
Update quine.cabal

### DIFF
--- a/quine.cabal
+++ b/quine.cabal
@@ -146,7 +146,7 @@ library
     optparse-applicative,
     primitive,
     process >= 1.2,
-    sdl2 >= 1.3,
+    sdl2 >= 1.3 && < 1.4,
     semigroups >= 0.17,
     StateVar >= 1.1 && < 1.2,
     stm >= 2.4.2,


### PR DESCRIPTION
Cabal try to download latest versions, but sdl2-2.0 API is completely different.