### PR TITLE
Allow building with sdl2-2.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
 
 matrix:
   allow_failures:
-    - env: GHCVER=head
+    - env: GHCVER=head MODE="-f-test-shaders -f-test-buffers -f-test-framebuffers"
 
 before_install:
   # If $GHCVER is the one travis has, don't bother reinstalling it.

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,8 +30,8 @@ before_install:
       travis_retry sudo add-apt-repository -y ppa:hvr/ghc
       travis_retry sudo apt-get update
       travis_retry sudo apt-get install cabal-install-1.24 ghc-$GHCVER happy
-      export CABAL=cabal-1.24
-      export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABAL/bin:$PATH
+      export CABAL=/opt/cabal/1.24/bin/cabal
+      export PATH=/opt/ghc/$GHCVER/bin:$PATH
     fi
   # Uncomment whenever hackage is down.
   # - mkdir -p ~/.cabal && cp travis/config ~/.cabal/config && $CABAL update

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
       travis_retry sudo apt-get update
       travis_retry sudo apt-get install cabal-install-1.24 ghc-$GHCVER happy
       export CABAL=cabal-1.24
-      export PATH=/opt/ghc/$GHCVER/bin:$PATH
+      export PATH=/opt/ghc/$GHCVER/bin:/opt/cabal/$CABAL/bin:$PATH
     fi
   # Uncomment whenever hackage is down.
   # - mkdir -p ~/.cabal && cp travis/config ~/.cabal/config && $CABAL update

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,9 @@ env:
 
 matrix:
   allow_failures:
-    - env: GHCVER=head MODE="-f-test-shaders -f-test-buffers -f-test-framebuffers"
+    - env: >
+           GHCVER=head
+           MODE="-f-test-shaders -f-test-buffers -f-test-framebuffers"
 
 before_install:
   # If $GHCVER is the one travis has, don't bother reinstalling it.

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: haskell
 
 env:
-  - > 
+  - >
     GHCVER=7.8.3
     MODE="-f-test-shaders -f-test-buffers -f-test-framebuffers"
   - >
@@ -46,8 +46,8 @@ before_install:
 
   # install SDL 2.0.3
   - export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
-  - wget http://libsdl.org/release/SDL2-2.0.3.tar.gz -O - | tar xz
-  - cd SDL2-2.0.3 && ./configure && make -j && sudo make install && cd ..
+  - wget http://libsdl.org/release/SDL2-2.0.5.tar.gz -O - | tar xz
+  - cd SDL2-2.0.5 && ./configure && make -j && sudo make install && cd ..
 
   # if we want GLFW-b
   # - sudo apt-get install libxxf86vm-dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ before_install:
   # If $GHCVER is the one travis has, don't bother reinstalling it.
   # We can also have faster builds by installing some libraries with
   # `apt`. If it isn't, install the GHC we want from hvr's PPA along
-  # with cabal-1.18.
+  # with cabal-1.24.
   - |
     if [ $GHCVER = `ghc --numeric-version` ]; then
       # Try installing some of the build-deps with apt-get for speed.
@@ -29,8 +29,8 @@ before_install:
       # Install the GHC we want from hvr's PPA
       travis_retry sudo add-apt-repository -y ppa:hvr/ghc
       travis_retry sudo apt-get update
-      travis_retry sudo apt-get install cabal-install-1.18 ghc-$GHCVER happy
-      export CABAL=cabal-1.18
+      travis_retry sudo apt-get install cabal-install-1.24 ghc-$GHCVER happy
+      export CABAL=cabal-1.24
       export PATH=/opt/ghc/$GHCVER/bin:$PATH
     fi
   # Uncomment whenever hackage is down.

--- a/quine.cabal
+++ b/quine.cabal
@@ -146,7 +146,7 @@ library
     optparse-applicative,
     primitive,
     process >= 1.2,
-    sdl2 >= 2.1.0 && < 2.2.0,
+    sdl2 >= 2.2.0 && < 2.3.0,
     semigroups >= 0.17,
     StateVar >= 1.1 && < 1.2,
     stm >= 2.4.2,

--- a/src/Quine/Input.hs
+++ b/src/Quine/Input.hs
@@ -9,7 +9,7 @@
 -- Portability: non-portable
 --
 -- Do we need to hook window entry to get a better state summary of the mouse buttons to avoid the common 'sticky mouse' problems in games?
--- 
+--
 -- Should losing focus kill the mouse button states?
 --------------------------------------------------------------------
 module Quine.Input
@@ -42,10 +42,10 @@ makeClassy ''Input
 
 instance Default Input where
   def = Input def def def 0 0 0 0
-  
+
 handleInputEvent :: (MonadState s m, HasInput s) => Event -> m ()
 handleInputEvent (KeyboardEvent SDL_KEYDOWN _ _ _ _ (Keysym sc kc _)) = do
-  keyCodes.contains kc .= True 
+  keyCodes.contains kc .= True
   scanCodes.contains sc .= True
 handleInputEvent (KeyboardEvent SDL_KEYUP _ _ _ _ (Keysym sc kc _)) = do
   keyCodes.contains kc  .= False
@@ -62,7 +62,7 @@ handleInputEvent (MouseButtonEvent SDL_MOUSEBUTTONUP _ _ mouse button _ _ x y) |
   mousePos .= V2 x y
   mouseButtons.contains button .= False
   mouseButtonMask.bitAt (fromIntegral button) .= False
-handleInputEvent (MouseWheelEvent SDL_MOUSEWHEEL _ _ mouse x y) | mouse /= SDL_TOUCH_MOUSEID =
+handleInputEvent (MouseWheelEvent SDL_MOUSEWHEEL _ _ mouse x y _) | mouse /= SDL_TOUCH_MOUSEID =
   mouseWheel += V2 x y
 handleInputEvent _ = return ()
 


### PR DESCRIPTION
Currently, `quine` fails to build with the latest `sdl2` Haskell library since the `MouseWheelEvent` constructor was given an extra field.