### PR TITLE
Fix the GHC 8.2 build by using a simple Setup.hs

### DIFF
--- a/Setup.lhs
+++ b/Setup.lhs
@@ -1,44 +1,7 @@
 #!/usr/bin/runhaskell
-\begin{code}
-{-# OPTIONS_GHC -Wall #-}
-module Main (main) where
+> module Main (main) where
 
-import Data.List ( nub )
-import Data.Version ( showVersion )
-import Distribution.Package ( PackageName(PackageName), PackageId, InstalledPackageId, packageVersion, packageName )
-import Distribution.PackageDescription ( PackageDescription(), TestSuite(..) )
-import Distribution.Simple ( defaultMainWithHooks, UserHooks(..), simpleUserHooks )
-import Distribution.Simple.Utils ( rewriteFile, createDirectoryIfMissingVerbose )
-import Distribution.Simple.BuildPaths ( autogenModulesDir )
-import Distribution.Simple.Setup ( BuildFlags(buildVerbosity), fromFlag)
-import Distribution.Simple.LocalBuildInfo ( withLibLBI, withTestLBI, LocalBuildInfo(), ComponentLocalBuildInfo(componentPackageDeps) )
-import Distribution.Verbosity ( Verbosity )
-import System.FilePath ( (</>) )
+> import Distribution.Simple
 
-main :: IO ()
-main = defaultMainWithHooks simpleUserHooks
-  { buildHook = \pkg lbi hooks flags -> do
-     generateBuildModule (fromFlag (buildVerbosity flags)) pkg lbi
-     buildHook simpleUserHooks pkg lbi hooks flags
-  }
-
-generateBuildModule :: Verbosity -> PackageDescription -> LocalBuildInfo -> IO ()
-generateBuildModule verbosity pkg lbi = do
-  let dir = autogenModulesDir lbi
-  createDirectoryIfMissingVerbose verbosity True dir
-  withLibLBI pkg lbi $ \_ libcfg -> do
-    withTestLBI pkg lbi $ \suite suitecfg -> do
-      rewriteFile (dir </> "Build_" ++ testName suite ++ ".hs") $ unlines
-        [ "module Build_" ++ testName suite ++ " where"
-        , "deps :: [String]"
-        , "deps = " ++ (show $ formatdeps (testDeps libcfg suitecfg))
-        ]
-  where
-    formatdeps = map (formatone . snd)
-    formatone p = case packageName p of
-      PackageName n -> n ++ "-" ++ showVersion (packageVersion p)
-
-testDeps :: ComponentLocalBuildInfo -> ComponentLocalBuildInfo -> [(InstalledPackageId, PackageId)]
-testDeps xs ys = nub $ componentPackageDeps xs ++ componentPackageDeps ys
-
-\end{code}
+> main :: IO ()
+> main = defaultMain

--- a/quine.cabal
+++ b/quine.cabal
@@ -10,7 +10,7 @@ stability:     experimental
 homepage:      http://github.com/ekmett/quine/
 bug-reports:   http://github.com/ekmett/quine/issues
 copyright:     Copyright (C) 2014-2015 Edward A. Kmett
-build-type:    Custom
+build-type:    Simple
 tested-with:   GHC == 7.10.2
 synopsis:      Quine
 description:   Quine


### PR DESCRIPTION
`quine` would build on GHC 8.2 were it not for the custom `Setup.hs` script:

```
$ cabal configure --enable-tests --enable-benchmarks -w ~/Software/ghc/inplace/bin/ghc-stage2 --allow-newer
Resolving dependencies...
[1 of 1] Compiling Main             ( dist/setup/setup.hs, dist/setup/Main.o )

dist/setup/setup.hs:8:31: error:
    Module
    ‘Distribution.Package’
    does not export
    ‘PackageName(PackageName)’
  |
8 | import Distribution.Package ( PackageName(PackageName), PackageId, InstalledPackageId, packageVersion, packageName )
  |                               ^^^^^^^^^^^^^^^^^^^^^^^^
```

But as far as I can tell, using a custom `Cabal` build type is completely unnecessary here, as `quine` doesn't actually use `doctests`! So I opted for the simple solution of just using a simple `Setup.hs` script instead.