### PR TITLE
Bumped LTS so quine compiles after the SDL version change, minor cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ old
 notes
 .ghci
 cabal.config
+.stack-work

--- a/Toy.hs
+++ b/Toy.hs
@@ -87,7 +87,7 @@ main = runInBoundThread $ withCString "quine" $ \windowName -> do
   ekg <- forkMonitor opts
 
   label "sdl.version" ekg >>= ($= show SDL.version)
- 
+
   -- start SDL
   init SDL_INIT_EVERYTHING >>= err
   contextMajorVersion $= 3
@@ -120,7 +120,7 @@ main = runInBoundThread $ withCString "quine" $ \windowName -> do
   label "gl.version" ekg          >>= ($= show GL.version)
   label "gl.shading.version" ekg  >>= ($= show shadingLanguageVersion)
   label "gl.shading.versions" ekg >>= ($= show shadingLanguageVersions)
-  
+
   -- glEnable gl_FRAMEBUFFER_SRGB
 
   throwErrors
@@ -128,7 +128,7 @@ main = runInBoundThread $ withCString "quine" $ \windowName -> do
   vw <- gauge "viewport.width" ekg
   vh <- gauge "viewport.height" ekg
   let sys = Env ekg opts fc vw vh
-      dsp = Display 
+      dsp = Display
         { _displayWindow            = window
         , _displayGL                = cxt
         , _displayFullScreen        = opts^.optionsFullScreen
@@ -169,20 +169,20 @@ core = do
   throwErrors
   currentProgram   $= scn
   boundVertexArray $= emptyVAO
-  forever $ do 
+  forever $ do
     (alpha,t) <- simulate $ poll $ \e -> handleDisplayEvent e >> handleInputEvent e
     displayMeter %= tick t
-    
-    displayFPS <- uses displayMeter fps 
+
+    displayFPS <- uses displayMeter fps
     physicsFPS <- uses simulationMeter fps
-    let title = showString "quine (display " 
+    let title = showString "quine (display "
             $ showFFloat (Just 1) displayFPS
             $ showString " fps, physics "
             $ showFFloat (Just 1) physicsFPS ")"
     use displayWindow >>= liftIO . withCString title . setWindowTitle
 
     updateCamera
-    resizeDisplay 
+    resizeDisplay
     render $ do
       (w,h) <- use displayWindowSize
       let wf = fromIntegral w

--- a/Triangles.hs
+++ b/Triangles.hs
@@ -93,7 +93,7 @@ programUniformCamera p s = liftIO $ do
   n   <- uniformLocation p $ "viewportCameraNear[" ++ show s ++ "]"
   f   <- uniformLocation p $ "viewportCameraFar[" ++ show s ++ "]"
   liftIO $ print pro
-  return $ UniformCamera 
+  return $ UniformCamera
       (SettableStateVar (uniformMat4 pro)) -- TODO programUniformMat4
       (SettableStateVar (uniformMat4 mv))
       (programUniform1f p fov)
@@ -118,7 +118,7 @@ instance HasLayoutAnnotation Vertex where
   layoutAnnotation p = Vertex
     { _vPosition = LayoutAnnotation $ Layout (components $ _vPosition <$> p) (baseType $ _vPosition <$> p) False (sizeOf (undefined::Vertex UnAnnotated)) nullPtr
     , _vColor    = LayoutAnnotation $ Layout (components $ _vColor <$> p) (baseType $ _vColor <$> p) False (sizeOf (undefined::Vertex UnAnnotated)) (nullPtr `plusPtr` sizeOf (undefined::Vec3))
-    } 
+    }
 
 -- * State
 
@@ -142,7 +142,7 @@ main = runInBoundThread $ withCString "quine" $ \windowName -> do
   ekg <- forkMonitor opts
 
   label "sdl.version" ekg >>= ($= show SDL.version)
- 
+
   -- start SDL
   init SDL_INIT_EVERYTHING >>= err
   contextMajorVersion $= 4
@@ -178,7 +178,7 @@ main = runInBoundThread $ withCString "quine" $ \windowName -> do
   label "gl.version" ekg          >>= ($= show GL.version)
   label "gl.shading.version" ekg  >>= ($= show shadingLanguageVersion)
   label "gl.shading.versions" ekg >>= ($= show shadingLanguageVersions)
-  
+
   -- glEnable gl_FRAMEBUFFER_SRGB
 
   throwErrors
@@ -186,7 +186,7 @@ main = runInBoundThread $ withCString "quine" $ \windowName -> do
   vw <- gauge "viewport.width" ekg
   vh <- gauge "viewport.height" ekg
   let sys = Env ekg opts fc vw vh
-      dsp = Display 
+      dsp = Display
         { _displayWindow            = window
         , _displayGL                = cxt
         , _displayFullScreen        = opts^.optionsFullScreen
@@ -218,7 +218,7 @@ core = do
   colorFrag     <- compile ["/shaders"] GL_FRAGMENT_SHADER "shaders/pass-color.frag"
   prog <- link [transformVert,colorFrag]
   currentProgram $= prog
-  
+
   Just aPosition <- attributeLocation prog "aPosition"
   Just aColor    <- attributeLocation prog "aColor"
 
@@ -251,18 +251,18 @@ core = do
   throwErrors
 
   liftIO $ putStrLn "starting loop. good luck..."
-  forever $ do 
-    
+  forever $ do
+
     (_alpha,t) <- simulate $ poll $ \e -> handleDisplayEvent e >> handleInputEvent e
-    displayFPS <- uses displayMeter fps 
+    displayFPS <- uses displayMeter fps
     physicsFPS <- uses simulationMeter fps
     displayMeter        %= tick t
-    let title = showString "quine (display " 
+    let title = showString "quine (display "
               $ showFFloat (Just 1) displayFPS
               $ showString " fps, physics "
               $ showFFloat (Just 1) physicsFPS ")"
     use displayWindow >>= liftIO . withCString title . setWindowTitle
-    resizeDisplay 
+    resizeDisplay
     updateCamera
 
     render $ do

--- a/quine.cabal
+++ b/quine.cabal
@@ -11,7 +11,7 @@ homepage:      http://github.com/ekmett/quine/
 bug-reports:   http://github.com/ekmett/quine/issues
 copyright:     Copyright (C) 2014-2015 Edward A. Kmett
 build-type:    Simple
-tested-with:   GHC == 7.10.2
+tested-with:   GHC == 8.0.2
 synopsis:      Quine
 description:   Quine
 

--- a/src/Quine/GL/Error.hs
+++ b/src/Quine/GL/Error.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable, DeriveGeneric, PatternSynonyms #-}
+ {-# LANGUAGE DeriveDataTypeable, DeriveGeneric, PatternSynonyms #-}
 --------------------------------------------------------------------
 -- |
 -- Copyright :  (c) 2014 Edward Kmett
@@ -20,7 +20,7 @@ module Quine.GL.Error
   , pattern StackUnderflow
   , pattern TableTooLarge
   , showError
-  , errors 
+  , errors
   , throwErrors
   , Errors(..)
   ) where
@@ -37,7 +37,7 @@ import Graphics.GL.Types
 -- | Used to represent the result of 'glGetError'
 newtype Error = Error GLenum deriving (Eq, Typeable, Data, Generic)
 
--- | No error has been recorded. 
+-- | No error has been recorded.
 pattern NoError = Error GL_NO_ERROR
 
 -- | An unacceptable value is specified for an enumerated argument.
@@ -46,7 +46,7 @@ pattern InvalidEnum = Error GL_INVALID_ENUM
 -- | A numeric argument is out of range.
 pattern InvalidValue = Error GL_INVALID_VALUE
 
--- | The specified operation is not allowed in the current state. 
+-- | The specified operation is not allowed in the current state.
 pattern InvalidOperation = Error GL_INVALID_OPERATION
 
 -- | The framebuffer object is not complete.
@@ -103,7 +103,7 @@ errors :: MonadIO m => m [Error]
 errors = liftIO $ go [] where
   go es = do
     e <- glGetError
-    if e == GL_NO_ERROR 
+    if e == GL_NO_ERROR
       then return $ reverse es
       else go $ Error e:es
 

--- a/src/Quine/Options.hs
+++ b/src/Quine/Options.hs
@@ -43,7 +43,7 @@ instance HasMonitorOptions Options where
 
 -- we need to set up the data directory first
 parseOptions :: Parser Options
-parseOptions = Options 
+parseOptions = Options
        <$> parseMonitorOptions
        <*> switch (long "full-screen" <> short 'f' <> help "open full-screen on launch")
        <*> switch (long "real-full-screen" <> short 'n' <> help "use real full screen; exiting is buggy on OS X with SDL 2.0.3")

--- a/src/Quine/Queue.hs
+++ b/src/Quine/Queue.hs
@@ -28,7 +28,7 @@ import Text.Read
 
 -- an _ephemeral_ work queue
 data Queue a = Queue [a] [a]
-  deriving (Functor, Data, Typeable, Generic) 
+  deriving (Functor, Data, Typeable, Generic)
 
 instance Show a => Show (Queue a) where
   showsPrec d q = showParen (d > 10) $
@@ -46,7 +46,7 @@ instance Eq a => Eq (Queue a) where
 instance Ord a => Ord (Queue a) where
   compare = compare `on` toList
 
-fromList :: [a] -> Queue a 
+fromList :: [a] -> Queue a
 fromList fs = Queue fs []
 
 null :: Queue a -> Bool

--- a/src/Quine/Ref.hs
+++ b/src/Quine/Ref.hs
@@ -40,7 +40,7 @@ data Ref a = Ref (IO ()) a !(IORef Int)
 instance Comonad Ref where
   extract (Ref _ a _) = a
   duplicate w@(Ref f _ r) = Ref f w r
-  
+
 -- | create a reference counter initialized to 1
 newRef :: MonadIO m => IO () -> a -> m (Ref a)
 newRef f a = liftIO $ Ref f a <$> newIORef 1

--- a/src/Quine/SDL.hsc
+++ b/src/Quine/SDL.hsc
@@ -12,7 +12,7 @@
 -- Prettier SDL bindings
 --------------------------------------------------------------------
 module Quine.SDL
-  ( 
+  (
   -- * Versioning
     version
   , revision
@@ -86,7 +86,7 @@ errOnNull p
 
 -- | Treat negative return codes as prompting an error check.
 err :: MonadIO m => CInt -> m ()
-err e 
+err e
   | e < 0 = liftIO $ do
     msg <- getError >>= peekCString
     clearError
@@ -116,7 +116,7 @@ revisionNumber = unsafePerformIO $ fromIntegral <$> getRevisionNumber
 {-# NOINLINE revisionNumber #-}
 
 -- * Attribute StateVars
-  
+
 -- | get\/set @SDL_GL_RED_SIZE@, the minimum number of bits for the red channel of the color buffer; defaults to 3
 redSize :: StateVar Int
 redSize = attr SDL_GL_RED_SIZE
@@ -169,11 +169,11 @@ multiSampleBuffers  = attr SDL_GL_MULTISAMPLEBUFFERS
 multiSampleSamples :: StateVar Int
 multiSampleSamples  = attr SDL_GL_MULTISAMPLESAMPLES
 
--- | get\/set @SDL_GL_CONTEXT_MAJOR_VERSION@, OpenGL context major version; see <https://wiki.libsdl.org/SDL_GLattr#OpenGL Remarks> for details 
+-- | get\/set @SDL_GL_CONTEXT_MAJOR_VERSION@, OpenGL context major version; see <https://wiki.libsdl.org/SDL_GLattr#OpenGL Remarks> for details
 contextMajorVersion :: StateVar Int
 contextMajorVersion = attr SDL_GL_CONTEXT_MAJOR_VERSION
 
--- | get\/set @SDL_GL_CONTEXT_MINOR_VERSION@, OpenGL context major version; see <https://wiki.libsdl.org/SDL_GLattr#OpenGL Remarks> for details 
+-- | get\/set @SDL_GL_CONTEXT_MINOR_VERSION@, OpenGL context major version; see <https://wiki.libsdl.org/SDL_GLattr#OpenGL Remarks> for details
 contextMinorVersion :: StateVar Int
 contextMinorVersion = attr SDL_GL_CONTEXT_MINOR_VERSION
 
@@ -235,7 +235,7 @@ windowDisplayMode :: Window -> StateVar DisplayMode
 windowDisplayMode w = StateVar getWDM setWDM where
   getWDM = alloca $ \p -> do
     getWindowDisplayMode w p >>= err
-    peek p 
+    peek p
   setWDM m = alloca $ \p -> do
     poke p m
     setWindowDisplayMode w p >>= err

--- a/src/Quine/Simulation.hs
+++ b/src/Quine/Simulation.hs
@@ -94,10 +94,10 @@ simulate poll = go simulationBurstRate
  where
   go b = do
     poll -- run this between physics frames
-    t <- now 
-    Simulation t0 tn ff ro rc m <- use simulation 
+    t <- now
+    Simulation t0 tn ff ro rc m <- use simulation
     let tn' = tn + simulationSPF
-    if b > 0 && tn' <= t 
+    if b > 0 && tn' <= t
       then do
         rn <- newState (extract ro) (extract rc) >>= \n -> newRef (deleteState n) n
         releaseRef ro

--- a/src/Quine/Task.hs
+++ b/src/Quine/Task.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE LambdaCase #-}
 -- |
 -- The GPU is an asynchronous resource, but we only have one controlling thread..
--- 
+--
 -- We can poll the GPU at various sync points
 module Quine.Task
   ( MonadTask(..)
@@ -38,7 +38,7 @@ instance Ord Fence where
   Fence a _ `compare` Fence b _ = compare a b
 
 class MonadIO m => MonadTask m where
-  -- | Start a task, this task may be run out of order with your own context. 
+  -- | Start a task, this task may be run out of order with your own context.
   --
   -- After running this command, assume that the context is scrambled.
   --
@@ -121,8 +121,8 @@ instance Monad Task where
 
 -- await a given fence, idling when we timeout
 drive :: Word64 -> IO () -> Heap -> Int -> Int -> IO ()
-drive d w (Heap (Fence l s) k hs) i j 
-  | l <= i       = k h i j -- we're already synchronized through to i. 
+drive d w (Heap (Fence l s) k hs) i j
+  | l <= i       = k h i j -- we're already synchronized through to i.
   | s == nullPtr = k h l j -- this is administrative, not a sync, l > i above
   | otherwise = go         -- use w >> go?
   where
@@ -136,8 +136,8 @@ drive d w (Heap (Fence l s) k hs) i j
 
 instance MonadIO Task where
   liftIO m = Task $ \k _ _ h i j -> do
-    a <- m 
-    k a h i j 
+    a <- m
+    k a h i j
 
 instance MonadTask Task where
   fence = Task $ \k _ _ h i j -> do
@@ -149,7 +149,7 @@ instance MonadTask Task where
     result <- newIORef Nothing
     let f = Fence j nullPtr
     let future h' i' j' = do
-          m (\ a h'' i'' j'' -> writeIORef result a >> 
+          m (\ a h'' i'' j'' -> writeIORef result a >>
     k (await f) (push f (\h i' j' -> ) h
 -}
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-4.0
+resolver: lts-8.15
 packages:
 - '.'
 extra-deps: []


### PR DESCRIPTION
Quine no longer compiled with lts 4.0 after SDL version increment, bumped LTS to 8.15 and everything compiles now.

 Minor additional cleanup - whitespace, add .stack-work to .gitignore.