### PR TITLE
Fix the build on GHC 8.4.1

### DIFF
--- a/quine.cabal
+++ b/quine.cabal
@@ -139,7 +139,7 @@ library
     gl >= 0.5,
     half,
     JuicyPixels,
-    lens,
+    lens >= 4.16.1,
     linear >= 1.15.4,
     monad-control >= 0.3.3,
     mtl,


### PR DESCRIPTION
Two changes were needed:

1. We need to add a `Semigroup` instance for `Ticks`.
2. On `lens-4.16` and earlier, the use of `(<&>)` from `lens` clashes with the newly added `(<&>)` counterpart in `base`. We need to require the use of `lens-4.16.1` or newer, which reexports `(<&>)` from `base` where available.