### PR TITLE
Add MonadFail constraint in Triangles example

### DIFF
--- a/Triangles.hs
+++ b/Triangles.hs
@@ -28,6 +28,7 @@ import Control.Exception.Lens
 import Control.Lens hiding (assign)
 import Control.Lens.Extras (is)
 import Control.Monad hiding (forM_)
+import Control.Monad.Fail (MonadFail)
 import Control.Monad.Reader
 import Control.Monad.State hiding (get)
 import Data.Default
@@ -209,7 +210,7 @@ main = runInBoundThread $ withCString "quine" $ \windowName -> do
 translate :: Vec3 -> Mat4
 translate v = identity & translation .~ v
 
-core :: (MonadIO m, MonadState s m, HasSystem s (), MonadReader e m, HasEnv e, HasOptions e) => m a
+core :: (MonadFail m, MonadIO m, MonadState s m, HasSystem s (), MonadReader e m, HasEnv e, HasOptions e) => m a
 core = do
   liftIO (getDir "shaders") >>= \ ss -> buildNamedStrings ss ("/shaders"</>)
   throwErrors

--- a/quine.cabal
+++ b/quine.cabal
@@ -221,6 +221,7 @@ executable triangles
       base >= 4.7 && < 5,
       containers,
       data-default,
+      fail,
       file-embed,
       filepath,
       gl,


### PR DESCRIPTION
The `Triangle` example was failing to build on GHC 8.6 because it enables `MonadFailDesugaring` by default, and there was no `MonadFail` constraint to support the partial pattern match in `core`.

Addresses one bullet point of ekmett/lens#815.